### PR TITLE
feat: nuevos query params (timezone & dias)

### DIFF
--- a/controllers/pronostico.js
+++ b/controllers/pronostico.js
@@ -58,6 +58,8 @@ const getPronostico = (req, res) => {
 const getPronosticoHora = (req, res) => {
   const latitude = req.query.latitud
   const longitude = req.query.longitud
+  let timezone = req.query.timezone ?? -3
+  timezone = convertirNumeroZonaHoraria(timezone)
   if (latitude == null) {
     res.status(400).json({
       msg: 'Error',
@@ -72,6 +74,7 @@ const getPronosticoHora = (req, res) => {
     })
     return
   }
+
   const hora = req.params.hora
   if (!Number.isInteger(+hora) || hora > 23 || hora < 0) {
     res.status(400).json({
@@ -80,7 +83,9 @@ const getPronosticoHora = (req, res) => {
     })
     return
   }
-  const url = `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&hourly=temperature_2m,apparent_temperature,precipitation_probability,rain&timezone=America%2FSao_Paulo&forecast_days=1`
+
+  const url = `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&hourly=temperature_2m,apparent_temperature,precipitation_probability,rain&timezone=${timezone}&forecast_days=1`
+
   axios
     .get(url)
     .then((response) => {

--- a/controllers/pronostico.js
+++ b/controllers/pronostico.js
@@ -1,8 +1,16 @@
 const axios = require('axios')
 
+const convertirNumeroZonaHoraria = (timezone) => {
+  const signo = timezone > 0 ? '-' : '+'
+  return encodeURIComponent(`Etc/GMT${signo}${Math.abs(timezone)}`)
+}
+
 const getPronostico = (req, res) => {
   const latitude = req.query.latitud
   const longitude = req.query.longitud
+  let timezone = req.query.timezone ?? -3
+  timezone = convertirNumeroZonaHoraria(timezone)
+  const days = req.query.dias ?? 7
   if (latitude == null) {
     res.status(400).json({
       msg: 'Error',
@@ -17,7 +25,9 @@ const getPronostico = (req, res) => {
     })
     return
   }
-  const url = `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&hourly=temperature_2m,apparent_temperature,precipitation_probability,rain&timezone=America%2FSao_Paulo&forecast_days=16`
+
+  const url = `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&hourly=temperature_2m,apparent_temperature,precipitation_probability,rain,weather_code&timezone=${timezone}&forecast_days=${days}`
+
   axios
     .get(url)
     .then((response) => {


### PR DESCRIPTION
Agregados 2 query params para `getPronostico`:

`timezone`: elegir la zona horaria
`dias`: cuantos dias de pronostico obtener (0-16)

También agregado `timezone` a `getPronosticoHora`